### PR TITLE
feat(config-options): Add option for season start year

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -2,28 +2,31 @@ import axios from 'axios';
 import capitalize from 'lodash.capitalize';
 import { Node } from './nodes';
 
-// TODO: Could have as a parameter the season
-const getAPIUrl = () => 'http://data.nba.net/10s/prod/v1/2017/players.json';
+const getAPIUrl = seasonStart =>
+  `http://data.nba.net/10s/prod/v1/${seasonStart}/players.json`;
 
-const getPlayerImage = personId => `https://ak-static.cms.nba.com/wp-content/uploads/headshots/nba/latest/260x190/${personId}.png`;
+const getPlayerImage = personId =>
+  `https://ak-static.cms.nba.com/wp-content/uploads/headshots/nba/latest/260x190/${personId}.png`;
 
-export async function sourceNodes({ actions }) {
+export async function sourceNodes({ actions }, pluginOptions) {
+  const now = new Date();
   const { createNode } = actions;
+  const { seasonStart = now.getFullYear() } = pluginOptions;
 
   // Make the request to the API
-  await axios.get(getAPIUrl()).then(response => response.data.league.standard
-  // Filter out players who did not play in the NBA
-    .filter(player => player.teams.length > 0)
-  // Filter players that did not play in the NBA since last season
-    .filter(player => player.teams[player.teams.length - 1].seasonEnd === '2017')
-  // eslint-disable-next-line array-callback-return
-    .map(player => {
-      const node = Node(capitalize('player'), {
-        ...player,
-        image: getPlayerImage(player.personId),
-      });
-      createNode(node);
-    }));
+  await axios.get(getAPIUrl(seasonStart)).then(response =>
+    response.data.league.standard
+      // Filter out players who did not play in the NBA
+      .filter(player => player.teams.length > 0)
+      // eslint-disable-next-line array-callback-return
+      .map(player => {
+        const node = Node(capitalize('player'), {
+          ...player,
+          image: getPlayerImage(player.personId),
+        });
+        createNode(node);
+      })
+  );
   // eslint-disable-next-line no-useless-return
   return;
 }


### PR DESCRIPTION
I didn't forget about this 😅 

Here's the config option for the season start year.

Defaults to the start year of the build. So if no `seasonStart` is provided today it would be 2019. Let me know if this makes sense to you and I can add the documentation as well.

**_Note:_** I did remove the filter of if the player had played that year because it was filtering out everything for me. Do we really need this?